### PR TITLE
shQuote() path to mailsend binary

### DIFF
--- a/R/send_email_out.R
+++ b/R/send_email_out.R
@@ -234,7 +234,7 @@ send_email_out <- function(message,
   # Send the message
   command <-
     glue::glue(
-"{paste0(getwd(), \"/mailsend\")} \\
+"{shQuote(paste0(getwd(), \"/mailsend\"))} \\
 -from \"{from}\" \\
 -name \"{sender}\" \\
 -t \"{to}\" \\


### PR DESCRIPTION
Without quoting the path, the `system()` command will throw an error if the current path contains whitespace characters.

I don't know if this is still relevant considering the [ongoing migration to mailsend-go](https://rich-iannone.github.io/blastula/articles/sending_using_smtp.html), but I thought I'd submit it anyway.