### PR TITLE
Fix bug introduced into `send_email_out()`

### DIFF
--- a/R/send_email_out.R
+++ b/R/send_email_out.R
@@ -85,7 +85,7 @@ send_email_out <- function(message,
 
   # Verify that the `message` object is of the
   # class `email_message`
-  if (!inherits(email, "email_message")) {
+  if (!inherits(message, "email_message")) {
     stop("The object provided in `email` must be an ",
          "`email_message` object.\n",
          " * This can be created with the `compose_email()` function.",


### PR DESCRIPTION
I'm guessing that no-one noticed this breaking change since the focus has since switched to `smtp_send()`?

Looks like it was introduced back in https://github.com/rich-iannone/blastula/commit/0837a5cf1c62fef081c9e535e632817b80d17d41

Not sure if you want to retain the old `message` argument name (as I've done here) or replace with `email` to make it consistent with `smtp_send()`? 

Although judging by the updated documentation I'm guessing you might eventually plan to deprecate `send_email_out()` in favour of `smtp_send()` at a later stage anyway. Maintaining the status quo and keeping the old argument name seems like the safest bet to me, especially if this functions days are numbered.