### PR TITLE
print mailsend-go stderr if non-zero exit code

### DIFF
--- a/R/smtp_send.R
+++ b/R/smtp_send.R
@@ -291,13 +291,15 @@ smtp_send <- function(email,
     send_result <-
       processx::run(
         command = binary_loc,
-        args = run_args
+        args = run_args,
+        error_on_status = FALSE
       )
 
     if (send_result$status == 0) {
       message("The email message was sent successfully.\n")
     } else {
       message("The email message was NOT successfully sent.\n")
+      message(send_result$stderr)
     }
   }
 }


### PR DESCRIPTION
I'm thinking this will help folks send more useful bug reports, e.g. https://github.com/rich-iannone/blastula/issues/63.

Probably `smtp_send` should return the processx result so users of the function can inspect the result to determine what to do next. I didn't include that change in this PR though.