### PR TITLE
Extend creds() so it accepts optional password argument

### DIFF
--- a/R/create_credentials.R
+++ b/R/create_credentials.R
@@ -157,11 +157,14 @@ create_smtp_creds_key <- function(id,
 #' @noRd
 create_credentials_list <- function(provider,
                                     user,
-                                    password = getPass::getPass("Enter the SMTP server password: "),
+                                    password,
                                     sender_name,
                                     host,
                                     port,
                                     use_ssl) {
+  if (missing(password) || is.null(password)) {
+    password <- getPass::getPass("Enter the SMTP server password: ")
+  }
 
   creds_internal(
     user = user,

--- a/R/create_credentials.R
+++ b/R/create_credentials.R
@@ -44,7 +44,7 @@ create_smtp_creds_file <- function(file,
 
   # Create a credentials list from the function inputs
   credentials_list <-
-    create_credentials_list(
+    create_credentials_list_with_prompt(
       provider = provider,
       user = user,
       sender_name = sender_name,
@@ -120,7 +120,7 @@ create_smtp_creds_key <- function(id,
 
   # Create a credentials list from the function inputs
   credentials_list <-
-    create_credentials_list(
+    create_credentials_list_with_prompt(
       provider = provider,
       user = user,
       sender_name = sender_name,
@@ -152,16 +152,16 @@ create_smtp_creds_key <- function(id,
   )
 }
 
-#' Create a credentials list object
+#' Create a credentials list object; prompt for a password if missing
 #'
 #' @noRd
-create_credentials_list <- function(provider,
-                                    user,
-                                    password,
-                                    sender_name,
-                                    host,
-                                    port,
-                                    use_ssl) {
+create_credentials_list_with_prompt <- function(provider,
+                                                user,
+                                                password,
+                                                sender_name,
+                                                host,
+                                                port,
+                                                use_ssl) {
   if (missing(password) || is.null(password)) {
     password <- getPass::getPass("Enter the SMTP server password: ")
   }

--- a/R/creds_helpers.R
+++ b/R/creds_helpers.R
@@ -62,7 +62,7 @@ creds <- function(user = NULL,
 
   # Create a credentials list from the function inputs
   creds_list <-
-    create_credentials_list(
+    create_credentials_list_with_prompt(
       user = user,
       password = password,
       provider = provider,

--- a/R/creds_helpers.R
+++ b/R/creds_helpers.R
@@ -53,6 +53,7 @@ NULL
 #' @rdname credential_helpers
 #' @export
 creds <- function(user = NULL,
+                  password = NULL,
                   provider = NULL,
                   sender_name = NULL,
                   host = NULL,
@@ -62,8 +63,9 @@ creds <- function(user = NULL,
   # Create a credentials list from the function inputs
   creds_list <-
     create_credentials_list(
-      provider = provider,
       user = user,
+      password = password,
+      provider = provider,
       sender_name = sender_name,
       host = host,
       port = port,


### PR DESCRIPTION
Trying to address the issue I opened: https://github.com/rich-iannone/blastula/issues/70

I also included a minor refactor--renamed `create_credentials_list` -> `create_credentials_list_with_prompt` to try to capture the meaning of that function.