### PR TITLE
send mail body as actual body instead of inline attachment

### DIFF
--- a/R/smtp_send.R
+++ b/R/smtp_send.R
@@ -249,10 +249,8 @@ smtp_send <- function(email,
       `-to` = to,
       `-cc` = cc,
       `-bcc` = bcc,
-      `attach` = no_options(),
-      `-file` = tempfile_,
-      `-mime-type` = "text/html",
-      `-inline` = no_options()
+      `body` = no_options(),
+      `-file` = tempfile_
     )
 
   # Create the vector of arguments related to file attachments

--- a/R/smtp_send.R
+++ b/R/smtp_send.R
@@ -250,7 +250,8 @@ smtp_send <- function(email,
       `-cc` = cc,
       `-bcc` = bcc,
       `body` = no_options(),
-      `-file` = tempfile_
+      `-file` = tempfile_, 
+      `-mime-type` = "text/html"
     )
 
   # Create the vector of arguments related to file attachments


### PR DESCRIPTION
~~and rely on mailsend-go's auto-detection of the MIME type~~

This fixes #55 