### PR TITLE
Make mail background color configurable

### DIFF
--- a/R/blastula_email_format.R
+++ b/R/blastula_email_format.R
@@ -38,6 +38,9 @@
 #'   default definition or R Markdown.
 #' @param connect_footer Should a prepared footer message with links be included
 #'   in the rendered email?
+#' @param background_color The color to use for the e-mail's background. You
+#'   can provide any valid color specification supported by the
+#'   [`background-color` CSS property](https://developer.mozilla.org/docs/Web/CSS/background-color).
 #' @param ... Specify other options in [rmarkdown::html_document()].
 #'
 #' @export
@@ -58,13 +61,15 @@ blastula_email <- function(toc = FALSE,
                            keep_md = FALSE,
                            md_extensions = NULL,
                            connect_footer = FALSE,
+                           background_color = "#f6f6f6",
                            ...) {
 
   if (template == "blastula") {
     template <- system.file("rmd", "template.html", package = "blastula")
   }
 
-  pandoc_args <- NULL
+  pandoc_args <- paste0("--variable=background-color:", background_color)
+
   if (isTRUE(connect_footer)) {
     pandoc_args <- c(
       pandoc_args,

--- a/R/bls_template.R
+++ b/R/bls_template.R
@@ -149,8 +149,8 @@ bls_standard_template <- function() {
 </xml>
 <![endif]-->
   </head>
-  <body style=\"font-family: Helvetica, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #f6f6f6; margin: 0; padding: 0;\">
-    <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" class=\"body\" style=\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;\" width=\"100%\" bgcolor=\"#f6f6f6\">
+  <body style=\"font-family: Helvetica, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: {background_color}; margin: 0; padding: 0;\">
+    <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" class=\"body\" style=\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: {background_color};\" width=\"100%\" bgcolor=\"{background_color}\">
       <tr>
         <td style=\"font-family: Helvetica, sans-serif; font-size: 14px; vertical-align: top;\" valign=\"top\">&nbsp;</td>
         <td class=\"container\" style=\"font-family: Helvetica, sans-serif; font-size: 14px; vertical-align: top; margin: 0 auto !important; max-width: 600px; padding: 0; padding-top: 24px; width: 600px;\" width=\"600\" valign=\"top\">

--- a/R/compose_email.R
+++ b/R/compose_email.R
@@ -13,6 +13,9 @@
 #'   in `...`. Alternatively, we can supply a set of `block_*()` calls enclosed
 #'   within the [blocks()] function to take advantage of precomposed HTML
 #'   blocks.
+#' @param background_color The color to use for the e-mail's background. You
+#'   can provide any valid color specification supported by the
+#'   [`background-color` CSS property](https://developer.mozilla.org/docs/Web/CSS/background-color).
 #' @param .title The title of the email message. This is not the subject but the
 #'   HTML title text which may appear in limited circumstances.
 #' @param .envir An opportunity to specify the environment. By default, this is
@@ -70,6 +73,7 @@
 compose_email <- function(body = NULL,
                           header = NULL,
                           footer = NULL,
+                          background_color = "#f6f6f6",
                           .title = NULL,
                           .envir = parent.frame(),
                           ...) {

--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -79,8 +79,8 @@ border-color: #34495e !important;
 }
 </style>
 </head>
-<body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
-<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;">
+<body class="" style="background-color: $background-color$; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: $background-color$;">
 <tr>
 <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
 <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 580px; padding: 10px; width: 580px;">

--- a/man/blastula_email.Rd
+++ b/man/blastula_email.Rd
@@ -9,7 +9,7 @@ blastula_email(toc = FALSE, toc_depth = 3, toc_float = FALSE,
   fig_height = 5, fig_retina = 2, fig_caption = TRUE, dev = "png",
   smart = TRUE, self_contained = TRUE, template = "blastula",
   includes = NULL, keep_md = FALSE, md_extensions = NULL,
-  connect_footer = FALSE, ...)
+  connect_footer = FALSE, background_color = "#f6f6f6", ...)
 }
 \arguments{
 \item{toc}{If you would like an automatically-generated table of contents in
@@ -65,6 +65,10 @@ default definition or R Markdown.}
 
 \item{connect_footer}{Should a prepared footer message with links be included
 in the rendered email?}
+
+\item{background_color}{The color to use for the e-mail's background. You
+can provide any valid color specification supported by the
+\href{https://developer.mozilla.org/docs/Web/CSS/background-color}{background-color CSS property}.}
 
 \item{...}{Specify other options in \code{\link[rmarkdown:html_document]{rmarkdown::html_document()}}.}
 }

--- a/man/compose_email.Rd
+++ b/man/compose_email.Rd
@@ -5,7 +5,8 @@
 \title{Create the email message body}
 \usage{
 compose_email(body = NULL, header = NULL, footer = NULL,
-  .title = NULL, .envir = parent.frame(), ...)
+  background_color = "#f6f6f6", .title = NULL,
+  .envir = parent.frame(), ...)
 }
 \arguments{
 \item{header, body, footer}{The three layout sections for an email message
@@ -14,6 +15,10 @@ these. String interpolation is enabled via curly braces and named arguments
 in \code{...}. Alternatively, we can supply a set of \code{block_*()} calls enclosed
 within the \code{\link[=blocks]{blocks()}} function to take advantage of precomposed HTML
 blocks.}
+
+\item{background_color}{The color to use for the e-mail's background. You
+can provide any valid color specification supported by the
+\href{https://developer.mozilla.org/docs/Web/CSS/background-color}{background-color CSS property}.}
 
 \item{.title}{The title of the email message. This is not the subject but the
 HTML title text which may appear in limited circumstances.}


### PR DESCRIPTION
This adds the parameter `background_color` to `compose_email()` and `blastula_email()` and fixes #81.