### PR TITLE
Fix test breakage on Windows

### DIFF
--- a/R/utils-html_manipulation.R
+++ b/R/utils-html_manipulation.R
@@ -89,7 +89,7 @@ gfsub <- function(string,
   }
 
   out(substr2(string, pos, nchar(string) + 1L))
-  paste(collapse = "\n", readLines(f, warn = FALSE))
+  paste(collapse = "\n", readLines(f, warn = FALSE, encoding = "UTF-8"))
 }
 
 # Like substr, but the end position is exclusive (i.e. it points

--- a/tests/testthat/test-html_manip.R
+++ b/tests/testthat/test-html_manip.R
@@ -5,6 +5,15 @@ test_that("HTML unescaping is properly performed", {
     expect_identical(src, "foo'\u27F5&BadEntity;bar.png")
     src
   })
+
+  # Tests that native encoding is parsed correctly as well
+  times_called <- 0L
+  replace_attr(enc2native("<img src='Á.png'/><img src='&Aacute;.png'/>"), "img", "src", function(src) {
+    expect_identical(Encoding(src), "UTF-8")
+    expect_identical(src, "Á.png")
+    times_called <<- times_called + 1L
+  })
+  expect_identical(times_called, 2L)
 })
 
 test_that("HTML escaping is properly performed", {


### PR DESCRIPTION
During gfsub, everything was written to a temp file with
proper UTF-8 encoding; however, when reading from that
temp file, I forgot to tag it as encoding="UTF-8".