### PR TITLE
Try to fix display issue where essential non-breaking spaces are converted to text

### DIFF
--- a/R/bls_template.R
+++ b/R/bls_template.R
@@ -149,7 +149,7 @@ bls_standard_template <-
   <body style=\"font-family: Helvetica, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #f6f6f6; margin: 0; padding: 0;\">
     <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" class=\"body\" style=\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;\" width=\"100%\" bgcolor=\"#f6f6f6\">
       <tr>
-        <td style=\"font-family: Helvetica, sans-serif; font-size: 14px; vertical-align: top;\" valign=\"top\">&nbsp;</td>
+        <td style=\"font-family: Helvetica, sans-serif; font-size: 14px; color: #f6f6f6; vertical-align: top;\" valign=\"top\">&nbsp;</td>
         <td class=\"container\" style=\"font-family: Helvetica, sans-serif; font-size: 14px; vertical-align: top; margin: 0 auto !important; max-width: 600px; padding: 0; padding-top: 24px; width: 600px;\" width=\"600\" valign=\"top\">
           <div class=\"content\" style=\"box-sizing: border-box; display: block; margin: 0 auto; max-width: 600px; padding: 0;\">
 
@@ -183,7 +183,7 @@ bls_standard_template <-
 
   <!-- END CENTERED WHITE CONTAINER --></div>
           </td>
-          <td style=\"font-family: sans-serif; font-size: 14px; vertical-align: top;\">&nbsp;</td>
+          <td style=\"font-family: sans-serif; font-size: 14px; color: #f6f6f6; vertical-align: top;\">&nbsp;</td>
         </tr>
       </table>
     </body>

--- a/R/bls_template.R
+++ b/R/bls_template.R
@@ -149,7 +149,7 @@ bls_standard_template <-
   <body style=\"font-family: Helvetica, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #f6f6f6; margin: 0; padding: 0;\">
     <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" class=\"body\" style=\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;\" width=\"100%\" bgcolor=\"#f6f6f6\">
       <tr>
-        <td style=\"font-family: Helvetica, sans-serif; font-size: 14px; color: #f6f6f6; vertical-align: top;\" valign=\"top\">&nbsp;</td>
+        <td style=\"font-family: Helvetica, sans-serif; font-size: 14px; vertical-align: top;\" valign=\"top\"><br /></td>
         <td class=\"container\" style=\"font-family: Helvetica, sans-serif; font-size: 14px; vertical-align: top; margin: 0 auto !important; max-width: 600px; padding: 0; padding-top: 24px; width: 600px;\" width=\"600\" valign=\"top\">
           <div class=\"content\" style=\"box-sizing: border-box; display: block; margin: 0 auto; max-width: 600px; padding: 0;\">
 
@@ -183,7 +183,7 @@ bls_standard_template <-
 
   <!-- END CENTERED WHITE CONTAINER --></div>
           </td>
-          <td style=\"font-family: sans-serif; font-size: 14px; color: #f6f6f6; vertical-align: top;\">&nbsp;</td>
+          <td style=\"font-family: sans-serif; font-size: 14px; vertical-align: top;\"><br /></td>
         </tr>
       </table>
     </body>

--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -82,7 +82,7 @@ border-color: #34495e !important;
 <body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
 <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;">
 <tr>
-<td style="font-family: sans-serif; font-size: 14px; color: #f6f6f6; vertical-align: top;">&nbsp;</td>
+<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;"><br /></td>
 <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 580px; padding: 10px; width: 580px;">
 <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 580px; padding: 10px;">
 
@@ -134,7 +134,7 @@ $endif$
 <!-- END CENTERED WHITE CONTAINER -->
 </div>
 </td>
-<td style="font-family: sans-serif; font-size: 14px; color: #f6f6f6; vertical-align: top;">&nbsp;</td>
+<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;"><br /></td>
 </tr>
 </table>
 </body>

--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -82,7 +82,7 @@ border-color: #34495e !important;
 <body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
 <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;">
 <tr>
-<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+<td style="font-family: sans-serif; font-size: 14px; color: #f6f6f6; vertical-align: top;">&nbsp;</td>
 <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 580px; padding: 10px; width: 580px;">
 <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 580px; padding: 10px;">
 
@@ -134,7 +134,7 @@ $endif$
 <!-- END CENTERED WHITE CONTAINER -->
 </div>
 </td>
-<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+<td style="font-family: sans-serif; font-size: 14px; color: #f6f6f6; vertical-align: top;">&nbsp;</td>
 </tr>
 </table>
 </body>


### PR DESCRIPTION
There can be a display issue when the non-breaking space in the left and right `<td>` elements can sometimes undergo conversion. Here is a screenshot that shows that `&nbsp;`s were converted to Â strings:

<img width="1062" alt="email_from_vagrant_connect" src="https://user-images.githubusercontent.com/5612024/68335723-01edf100-00ab-11ea-93dc-6bcd2c6e415c.png">

However, we need these non-breaking spaces (or equivalent characters for both).

The compromise here is to color the space (or its replacement string) the same color as the background. For the inline style that governs the `&nbsp;`, a `color` style rule was added. The color matches the background of the email (i.e., *not* the center, white wrapper). These changes were applied to the `bls_template.R` file and the .Rmd template, so it should apply to emails made by `compose_email()` and those made with R Markdown files and published to Connect.

All tests pass from this change. We do need to send Connect emails via Vagrant/Connect (where the issue appeared) to see if this fix is successful.
