### PR TITLE
Apply CSS rules to the <img> tag

### DIFF
--- a/R/bls_template.R
+++ b/R/bls_template.R
@@ -31,6 +31,11 @@ bls_standard_template <-
     }
 
     @media all {
+      img {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
       .btn-secondary a:hover {
         border-color: #34495e !important;
         color: #34495e !important;

--- a/R/bls_template.R
+++ b/R/bls_template.R
@@ -32,9 +32,7 @@ bls_standard_template <-
 
     @media all {
       img {
-        height: auto !important;
         max-width: 100% !important;
-        width: auto !important;
       }
       .btn-secondary a:hover {
         border-color: #34495e !important;

--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -52,9 +52,7 @@ PRESERVE THESE STYLES IN THE HEAD
 @media all {
 
 img {
-height: auto !important;
 max-width: 100% !important;
-width: auto !important;
 }
 
 .ExternalClass {

--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -50,6 +50,13 @@ width: auto !important;
 PRESERVE THESE STYLES IN THE HEAD
 ------------------------------------- */
 @media all {
+
+img {
+height: auto !important;
+max-width: 100% !important;
+width: auto !important;
+}
+
 .ExternalClass {
 width: 100%;
 }


### PR DESCRIPTION
This change makes all images responsive, with a max-width of 100% .

The change was tested in RStudio and a very large external image scaled to 100% of the width of its container.

```r
email <- 
  compose_email(
    body = md(
      "
## Hello

This is an image with a max-width set (for all media widths)

![](https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png)

"
    )
  )

email
```

<img width="706" alt="max-width-fix" src="https://user-images.githubusercontent.com/5612024/68351621-01b51c00-00d2-11ea-9b6f-56cbcb06c34c.png">

Changes were applied to templates for `compose_email()` and for the Connect/Rmd application.