### PR TITLE
Use `htmlEscape()` on attrs and text

### DIFF
--- a/R/add_cta_button.R
+++ b/R/add_cta_button.R
@@ -46,11 +46,11 @@ add_cta_button <- function(url,
 <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" class=\"btn btn-primary\" style=\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;\">
 <tbody>
 <tr>
-<td align=\"", align, "\" style=\"font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;\">
+<td align=\"", align %>% htmltools::htmlEscape(attribute = TRUE), "\" style=\"font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;\">
 <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;\">
 <tbody>
 <tr>
-<td style=\"font-family: sans-serif; font-size: 14px; vertical-align: top; background-color: #3498db; border-radius: 5px; text-align: center;\"> <a href=\"", url, "\" target=\"_blank\" style=\"display: inline-block; color: #ffffff; background-color: #3498db; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-transform: capitalize; border-color: #3498db;\">", text, "</a> </td>
+<td style=\"font-family: sans-serif; font-size: 14px; vertical-align: top; background-color: #3498db; border-radius: 5px; text-align: center;\"> <a href=\"", url %>% htmltools::htmlEscape(attribute = TRUE), "\" target=\"_blank\" style=\"display: inline-block; color: #ffffff; background-color: #3498db; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-transform: capitalize; border-color: #3498db;\">", text %>% htmltools::htmlEscape(), "</a> </td>
 </tr>
 </tbody>
 </table>

--- a/R/add_image.R
+++ b/R/add_image.R
@@ -68,6 +68,6 @@ add_image <- function(file, alt = NULL) {
   paste0(
     "<img cid=\"", cid,
     "\" src=\"", uri,
-    "\" width=\"520\" alt=\"", alt_text, "\"/>\n"
+    "\" width=\"520\" alt=\"", alt_text %>% htmltools::htmlEscape(attribute = TRUE), "\"/>\n"
   )
 }


### PR DESCRIPTION
These changes apply `htmltools::htmlEscape()` on attribute values and text in the `add_cta_button()` and `add_image()` functions. 

Joe, I didn't add any escaping on the `cid` or `uri` values in `add_image()`. Let me know if that really ought to be done and I'll make that change.