### PR TITLE
Correct the function name in the .Rmd email preview 

### DIFF
--- a/R/connect_email.R
+++ b/R/connect_email.R
@@ -163,7 +163,7 @@ create_rmd_preview_message <- function(subject = NULL) {
       "This is an email preview for RStudio Connect</h2>",
       "<p style=\"text-align: center; background:#fcfcfc; ",
       "padding-top: 0; margin-top: 0;\">",
-      "Use <code>connect_email(preview = FALSE)</code> ",
+      "Use <code>attach_connect_email(preview = FALSE)</code> ",
       "to attach without this preview.",
       subject_ln,
       "</p><hr></div>"


### PR DESCRIPTION
The correction updates the name of the relevant function to the current name of `attach_connect_email()` (and not `connect_email()`). This is in the message shown at the top of an .Rmd email preview window.
