### PR TITLE
Make correction to Connect-based email footer

### DIFF
--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -121,7 +121,7 @@ $include-after$
 $endfor$
 $if(rsc-footer)$
 $if(include-after)$<hr/>$endif$
-<p>The connect-example-main document was generated at $rsc-date-time$ by scheduled execution.</p>
+<p>This message was generated at $rsc-date-time$.</p>
 
 <p>This Version: <a href="$rsc-report-rendering-url$">$rsc-report-rendering-url$</a><br/>
 Latest Version: <a href="$rsc-report-url$">$rsc-report-url$</a></p>


### PR DESCRIPTION
This change corrects the Connect-based email footer. Previously, it had a hard-coded document name and incorrect, misleading information.