### PR TITLE
Make a correction to the `smtp_send()` docs

### DIFF
--- a/R/smtp_send.R
+++ b/R/smtp_send.R
@@ -18,8 +18,7 @@
 #' @param to A vector of email addresses serving as primary recipients for the
 #'   message. For secondary recipients, use the `cc` and `bcc` arguments. A
 #'   named character vector can be used to specify the recipient names along
-#'   with the their email address (e.g., `c("The Recipient",
-#'   "recipient@example.com")`).
+#'   with the their email address (e.g., `c("The Recipient" = "recipient@example.com")`).
 #' @param from The email address of the sender. Often this needs to be the same
 #'   email address that is associated with the account actually sending the
 #'   message. As with `to`, `cc`, and `bcc`, we can either supply a single email
@@ -35,7 +34,7 @@
 #'   The BCC list differs in that those recipients will be concealed from all
 #'   other recipients (including those on the BCC list). A named character
 #'   vector can be used to specify the recipient names along with the their
-#'   email address (e.g., `c("The Recipient", "recipient@example.com")`).
+#'   email address (e.g., `c("The Recipient" = "recipient@example.com")`).
 #' @param credentials One of three credential helper functions must be used
 #'   here: (1) [creds()], (2) [creds_key()], or (3) [creds_file()]. The first,
 #'   [creds()], allows for a manual specification of SMTP configuration and

--- a/R/smtp_send.R
+++ b/R/smtp_send.R
@@ -24,7 +24,7 @@
 #'   email address that is associated with the account actually sending the
 #'   message. As with `to`, `cc`, and `bcc`, we can either supply a single email
 #'   address or use a named character vector with the sender name and email
-#'   address (e.g., `c("The Sender", "sender@example.com")`).
+#'   address (e.g., `c("The Sender" = "sender@example.com")`).
 #' @param subject The subject of the message, which is usually a brief summary
 #'   of the topic of the message. If not provided, an empty string will be used
 #'   (which is handled differently by email clients).

--- a/man/smtp_send.Rd
+++ b/man/smtp_send.Rd
@@ -14,7 +14,7 @@ function. The object's class is \code{email_message}.}
 \item{to}{A vector of email addresses serving as primary recipients for the
 message. For secondary recipients, use the \code{cc} and \code{bcc} arguments. A
 named character vector can be used to specify the recipient names along
-with the their email address (e.g., \code{c("The Recipient", "recipient@example.com")}).}
+with the their email address (e.g., \code{c("The Recipient" = "recipient@example.com")}).}
 
 \item{from}{The email address of the sender. Often this needs to be the same
 email address that is associated with the account actually sending the
@@ -33,7 +33,7 @@ listing of recipients is visible to all other recipients of the message.
 The BCC list differs in that those recipients will be concealed from all
 other recipients (including those on the BCC list). A named character
 vector can be used to specify the recipient names along with the their
-email address (e.g., \code{c("The Recipient", "recipient@example.com")}).}
+email address (e.g., \code{c("The Recipient" = "recipient@example.com")}).}
 
 \item{credentials}{One of three credential helper functions must be used
 here: (1) \code{\link[=creds]{creds()}}, (2) \code{\link[=creds_key]{creds_key()}}, or (3) \code{\link[=creds_file]{creds_file()}}. The first,

--- a/man/smtp_send.Rd
+++ b/man/smtp_send.Rd
@@ -20,7 +20,7 @@ with the their email address (e.g., \code{c("The Recipient", "recipient@example.
 email address that is associated with the account actually sending the
 message. As with \code{to}, \code{cc}, and \code{bcc}, we can either supply a single email
 address or use a named character vector with the sender name and email
-address (e.g., \code{c("The Sender", "sender@example.com")}).}
+address (e.g., \code{c("The Sender" = "sender@example.com")}).}
 
 \item{subject}{The subject of the message, which is usually a brief summary
 of the topic of the message. If not provided, an empty string will be used


### PR DESCRIPTION
This fixes a mistake in the documentation for the `smtp_send()` function. The text for the `from` argument has been updated.