### PR TITLE
V0.3.1 rc (release for addressing CRAN errors)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: blastula
 Title: Easily Send HTML Email Messages
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("Richard", "Iannone", role = c("aut", "cre"), email = "riannone@me.com",
            comment = c(ORCID = "0000-0003-3925-190X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,6 +45,7 @@ Suggests:
     knitr,
     spelling,
     xml2
+SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# blastula 0.3.1
+
+This release contains fixes for R CMD check problems on CRAN test machines. 
+
 # blastula 0.3.0
 
 The **blastula** package has transitioned to using the **curl** package for SMTP mailing.

--- a/R/create_credentials.R
+++ b/R/create_credentials.R
@@ -155,12 +155,24 @@ create_smtp_creds_key <- function(id,
   # nocov end
 }
 
+#' Ask for a password
+#'
+#' @noRd
+get_password <- function(msg = "Enter the SMTP server password: ") {
+
+  # nocov start
+
+  getPass::getPass(msg = msg)
+
+  # nocov end
+}
+
 #' Create a credentials list object
 #'
 #' @noRd
 create_credentials_list <- function(provider,
                                     user,
-                                    password = getPass::getPass("Enter the SMTP server password: "),
+                                    password = get_password(),
                                     host,
                                     port,
                                     use_ssl) {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -2,7 +2,7 @@ context("Utility functions work as expected")
 
 test_that("knitr_sidecar_prefix preconditions hold", {
 
-  if (rmarkdown:::pandoc2.0()) {
+  if (rmarkdown::pandoc_available()) {
 
     # Ensure that rmarkdown assumptions still hold
     rmd_path <- file.path(tempdir(), "test-utils.Rmd")
@@ -15,7 +15,7 @@ test_that("knitr_sidecar_prefix preconditions hold", {
 
 test_that("knitr_sidecar_prefix behavior", {
 
-  if (rmarkdown:::pandoc2.0()) {
+  if (rmarkdown::pandoc_available()) {
 
     # fig.path isn't set
     expect_null(knitr_sidecar_prefix(NULL))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -2,47 +2,52 @@ context("Utility functions work as expected")
 
 test_that("knitr_sidecar_prefix preconditions hold", {
 
-  # Ensure that rmarkdown assumptions still hold
-  rmd_path <- file.path(tempdir(), "test-utils.Rmd")
+  if (rmarkdown:::pandoc2.0()) {
 
-  file.copy(testthat::test_path("test-utils.Rmd"), rmd_path)
+    # Ensure that rmarkdown assumptions still hold
+    rmd_path <- file.path(tempdir(), "test-utils.Rmd")
 
-  rmarkdown::render(rmd_path, quiet = TRUE)
+    file.copy(testthat::test_path("test-utils.Rmd"), rmd_path)
+
+    rmarkdown::render(rmd_path, quiet = TRUE)
+  }
 })
 
 test_that("knitr_sidecar_prefix behavior", {
 
-  # fig.path isn't set
-  expect_null(knitr_sidecar_prefix(NULL))
-  expect_null(knitr_sidecar_prefix(NULL, condition = FALSE))
-  expect_null(knitr_sidecar_prefix(NULL, condition = TRUE))
-  expect_identical("default", knitr_sidecar_prefix("default"))
-  expect_identical("default", knitr_sidecar_prefix("default", condition = FALSE))
-  expect_identical("default", knitr_sidecar_prefix("default", condition = TRUE))
+  if (rmarkdown:::pandoc2.0()) {
 
-  # Explicitly provide an unusable fig.path
-  expect_null(knitr_sidecar_prefix(NULL, fig_path = "."))
-  expect_null(knitr_sidecar_prefix(NULL, condition = FALSE, fig_path = "."))
-  expect_null(knitr_sidecar_prefix(NULL, condition = TRUE, fig_path = "."))
-  expect_identical("default", knitr_sidecar_prefix("default", fig_path = "."))
-  expect_identical("default", knitr_sidecar_prefix("default", condition = FALSE, fig_path = "."))
-  expect_identical("default", knitr_sidecar_prefix("default", condition = TRUE, fig_path = "."))
+    # fig.path isn't set
+    expect_null(knitr_sidecar_prefix(NULL))
+    expect_null(knitr_sidecar_prefix(NULL, condition = FALSE))
+    expect_null(knitr_sidecar_prefix(NULL, condition = TRUE))
+    expect_identical("default", knitr_sidecar_prefix("default"))
+    expect_identical("default", knitr_sidecar_prefix("default", condition = FALSE))
+    expect_identical("default", knitr_sidecar_prefix("default", condition = TRUE))
 
-  # Usable fig.path provided
-  expect_identical(
-    knitr_sidecar_prefix(NULL, condition = TRUE,
-      fig_path = "a12 !_-x_files/b_files/figure-github_flavored_markdown/"),
-    "a12 !_-x_files/b"
-  )
-  expect_null(
-    knitr_sidecar_prefix(NULL, condition = FALSE,
-      fig_path = "a12 !_-x_files/b_files/figure-github_flavored_markdown/")
-  )
-  expect_null(
-    knitr_sidecar_prefix(NULL,
-      fig_path = "a12 !_-x_files/b_files/figure-github_flavored_markdown/")
-  )
+    # Explicitly provide an unusable fig.path
+    expect_null(knitr_sidecar_prefix(NULL, fig_path = "."))
+    expect_null(knitr_sidecar_prefix(NULL, condition = FALSE, fig_path = "."))
+    expect_null(knitr_sidecar_prefix(NULL, condition = TRUE, fig_path = "."))
+    expect_identical("default", knitr_sidecar_prefix("default", fig_path = "."))
+    expect_identical("default", knitr_sidecar_prefix("default", condition = FALSE, fig_path = "."))
+    expect_identical("default", knitr_sidecar_prefix("default", condition = TRUE, fig_path = "."))
 
+    # Usable fig.path provided
+    expect_identical(
+      knitr_sidecar_prefix(NULL, condition = TRUE,
+                           fig_path = "a12 !_-x_files/b_files/figure-github_flavored_markdown/"),
+      "a12 !_-x_files/b"
+    )
+    expect_null(
+      knitr_sidecar_prefix(NULL, condition = FALSE,
+                           fig_path = "a12 !_-x_files/b_files/figure-github_flavored_markdown/")
+    )
+    expect_null(
+      knitr_sidecar_prefix(NULL,
+                           fig_path = "a12 !_-x_files/b_files/figure-github_flavored_markdown/")
+    )
+  }
 })
 
 test_that("the `smtp_settings()` function returns the expected output", {


### PR DESCRIPTION
This bugfix release addresses a NOTE and an ERROR that results from not having Pandoc available on the check system (in this case, the CRAN Solaris test machine).

Here is the R CMD check log that this release is meant to address:

```
using R version 3.6.1 Patched (2019-11-20 r77446)
using platform: i386-pc-solaris2.10 (32-bit)
using session charset: UTF-8
using option ‘--no-stop-on-test-error’
checking for file ‘blastula/DESCRIPTION’ ... OK
checking extension type ... Package
this is package ‘blastula’ version ‘0.3.0’
package encoding: UTF-8
checking package namespace information ... OK
checking package dependencies ... OK
checking if this is a source package ... OK
checking if there is a namespace ... OK
checking for executable files ... OK
checking for hidden files and directories ... OK
checking for portable file names ... OK
checking for sufficient/correct file permissions ... OK
checking whether package ‘blastula’ can be installed ... OK
checking installed package size ... OK
checking package directory ... OK
checking ‘build’ directory ... OK
checking DESCRIPTION meta-information ... OK
checking top-level files ... OK
checking for left-over files ... OK
checking index information ... OK
checking package subdirectories ... OK
checking R files for non-ASCII characters ... OK
checking R files for syntax errors ... OK
checking whether the package can be loaded ... OK
checking whether the package can be loaded with stated dependencies ... OK
checking whether the package can be unloaded cleanly ... OK
checking whether the namespace can be loaded with stated dependencies ... OK
checking whether the namespace can be unloaded cleanly ... OK
checking loading without being on the library search path ... OK
checking use of S3 registration ... OK
checking dependencies in R code ... NOTE
Namespace in Imports field not imported from: ‘getPass’
  All declared Imports should be used.
checking S3 generic/method consistency ... OK
checking replacement functions ... OK
checking foreign function calls ... OK
checking R code for possible problems ... OK
checking Rd files ... OK
checking Rd metadata ... OK
checking Rd cross-references ... OK
checking for missing documentation entries ... OK
checking for code/documentation mismatches ... OK
checking Rd \usage sections ... OK
checking Rd contents ... OK
checking for unstated dependencies in examples ... OK
checking R/sysdata.rda ... OK
checking installed files from ‘inst/doc’ ... OK
checking files in ‘vignettes’ ... OK
checking examples ... OK
checking for unstated dependencies in ‘tests’ ... OK
checking tests ... [13s/18s] ERROR
  Running ‘spelling.R’
  Running ‘testthat.R’ [12s/16s]
Running the tests in ‘tests/testthat.R’ failed.
Complete output:
  > library(testthat)
  > library(blastula)
  > 
  > test_check("blastula")
  ── 1. Error: knitr_sidecar_prefix preconditions hold (@test-utils.R#10) ───────
  pandoc version 1.12.3 or higher is required and was not found (see the help page ?rmarkdown::pandoc_available).
  Backtrace:
   1. rmarkdown::render(rmd_path, quiet = TRUE)
   2. rmarkdown::pandoc_available(required_pandoc, error = TRUE)
  
  ══ testthat results ═══════════════════════════════════════════════════════════
  [ OK: 188 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 1 ]
  1. Error: knitr_sidecar_prefix preconditions hold (@test-utils.R#10) 
  
  Error: testthat unit tests failed
  Execution halted
checking for unstated dependencies in vignettes ... OK
checking package vignettes in ‘inst/doc’ ... OK
checking re-building of vignette outputs ... OK
checking PDF version of manual ... OK
checking for detritus in the temp directory ... OK
DONE
Status: 1 ERROR, 1 NOTE
```