### PR TITLE
Smtp send tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ status](https://www.r-pkg.org/badges/version/blastula)](https://CRAN.R-project.o
 [![Travis-CI Build
 Status](https://travis-ci.org/rich-iannone/blastula.svg?branch=master)](https://travis-ci.org/rich-iannone/blastula)
 [![Codecov test
-coverage](https://codecov.io/gh/rich-iannone/blastula/branch/master/graph/badge.svg)](https://codecov.io/gh/rich-iannone/blastula?branch=master)
+coverage](https://codecov.io/gh/pilipino/blastula/branch/master/graph/badge.svg)](https://codecov.io/gh/pilipino/blastula?branch=master)
 
 ## Overview
 

--- a/tests/testthat/test-smtp_send.R
+++ b/tests/testthat/test-smtp_send.R
@@ -1,0 +1,32 @@
+context("SMTP send")
+
+test_that("Email is of expected format", {
+  # Illegal inputs
+  expect_error(smtp_send("hello"))
+})
+
+test_that("Creds File Deprecation", {
+
+  email <- compose_email("email")
+
+  cf <- creds_file(create_smtp_creds_file(
+    file = "test_creds_file",
+    user = "sender@email.com",
+    provider = "gmail"))
+
+  expect_error(smtp_send(email=email, from = "sender@email.com",to = "recipient@email.com",
+                         creds_file = cf))
+})
+
+test_that("Credentials is NULL", {
+  email <- compose_email("email")
+  expect_error(smtp_send(email, from = "sender@email.com",to = "recipient@email.com", credentials=NULL))
+})
+
+
+test_that("Credentials is Blastula class", {
+
+  expect_error(smtp_send(from = "sender@email.com",to = "recipient@email.com",
+                         "hello"
+  ))
+})


### PR DESCRIPTION
Good day! 
I am a Google Code-in participant, wherein we were tasked to find r packages and try to increase the code coverage. I am still a super git newb, but wanted to try it out. I have recently added a test for the smtp-send function. 

So far, from the current 
<img src="https://codecov.io/gh/rich-iannone/blastula/branch/master/graph/badge.svg">, 
I was able to raise it to a 
<img src="https://codecov.io/gh/pilipino/blastula/branch/master/graph/badge.svg">. 

I completely understand that this is far from a drastic improvement, and indeed I wish to increase the code coverage by a couple more points. I've seen the note that `send_mail()` function might be removed so I haven't added tests there yet.

Please advise sir @rich-iannone if this would be a good test to add and if so, I would just like to ask your advice on why I keep getting this error:

` Error in readLines(file_name, encoding = "UTF-8") : 
  'con' is not a connection `

Thank you very much for your time! :)