### PR TITLE
Fix broken rendering on Outlook

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Fixed buggy internal logic for decoding numeric HTML entities that represent non-ASCII characters.
 
-* Fixed incorrect rendering in Outlook, due to wrong line endings used for quoted-printable encoding.
+* Fixed incorrect rendering in Outlook, due to wrong line endings used for quoted-printable encoding. Thanks @jdbarillas for identifying the source of the issue! [#153](https://github.com/rich-iannone/blastula/pull/153)
 
 # blastula 0.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fixed buggy internal logic for decoding numeric HTML entities that represent non-ASCII characters.
 
+* Fixed incorrect rendering in Outlook, due to wrong line endings used for quoted-printable encoding.
+
 # blastula 0.3.1
 
 This release contains fixes for R CMD check problems on CRAN test machines. 

--- a/R/mime.R
+++ b/R/mime.R
@@ -41,7 +41,8 @@ generate_rfc2822 <- function(eml,
                              subject = NULL,
                              from = NULL,
                              to = NULL,
-                             cc = NULL) {
+                             cc = NULL,
+                             con = NULL) {
 
   stopifnot(inherits(eml, "blastula_message"))
 
@@ -112,10 +113,19 @@ generate_rfc2822 <- function(eml,
     )
   }
 
-  f <- file(open = "w+b")
-  on.exit(close(f), add = TRUE)
-  write_mime(create_output_sink(f), msg)
-  readChar(f, seek(f), useBytes = TRUE)
+  if (is.null(con)) {
+    f <- file(open = "w+b")
+    on.exit(close(f), add = TRUE)
+    write_mime(create_output_sink(f), msg)
+    readChar(f, seek(f), useBytes = TRUE)
+  } else {
+    if (is.character(con)) {
+      con <- file(con, open = "w+b")
+      on.exit(close(con), add = TRUE)
+    }
+    write_mime(create_output_sink(con), msg)
+    invisible()
+  }
 }
 
 # Constant representing canonical CRLF

--- a/R/mime.R
+++ b/R/mime.R
@@ -269,7 +269,7 @@ encode_qp <- function(str) {
   # Ensure that trailing spaces are not ignored
   out("=\r\n\r\n")
 
-  paste(collapse = "\n", readLines(f, warn = FALSE, encoding = "UTF-8"))
+  paste(collapse = "\r\n", readLines(f, warn = FALSE, encoding = "UTF-8"))
 }
 
 format_rfc2822_date <- function(date) {

--- a/tests/testthat/test-mime.R
+++ b/tests/testthat/test-mime.R
@@ -138,15 +138,22 @@ test_that("varying formats for recipient lists work as expected", {
   ) %>%
     expect_match("Subject: Don't \"sweat it\", okay?")
 
-# TODO:
-# Inline images and file attachments with weird filenames
-#   Filenames with spaces
-#   Filenames with unicode characters (on both Windows and POSIX)
-#   Filenames with angle brackets < >
-#   With various extensions
+  # TODO:
+  # Inline images and file attachments with weird filenames
+  #   Filenames with spaces
+  #   Filenames with unicode characters (on both Windows and POSIX)
+  #   Filenames with angle brackets < >
+  #   With various extensions
 
-  # TODO: A test email with text lines > 80 characters, and some small binary
-  # attachment (image is fine). After calling generate_rfc2822 on it, ensure
-  # that grepl("(?<!\\r)\n", str, perl = TRUE) is FALSE
-
+  # Create a test email with text lines > 80 characters and a
+  # small binary attachment (an image); after calling
+  # `generate_rfc2822()` on it, expect that `grepl("(?<!\\r)\n", str, perl = TRUE)`
+  # returns FALSE
+  blastula::prepare_test_message(
+    incl_ggplot = FALSE, incl_image = FALSE
+  ) %>%
+    add_attachment(file = "tests/testthat/rstudio_logo.png") %>%
+    generate_rfc2822() %>%
+    grepl("(?<!\\r)\n", ., perl = TRUE) %>%
+    expect_false()
 })

--- a/tests/testthat/test-mime.R
+++ b/tests/testthat/test-mime.R
@@ -152,7 +152,7 @@ test_that("varying formats for recipient lists work as expected", {
   blastula::prepare_test_message(
     incl_ggplot = FALSE, incl_image = FALSE
   ) %>%
-    add_attachment(file = file.path(path.package("blastula"), "tests/testthat/rstudio_logo.png")) %>%
+    add_attachment(file = system.file("img", "pexels-photo-267151.jpeg", package = "blastula")) %>%
     generate_rfc2822() %>%
     grepl("(?<!\\r)\n", ., perl = TRUE) %>%
     expect_false()

--- a/tests/testthat/test-mime.R
+++ b/tests/testthat/test-mime.R
@@ -145,4 +145,8 @@ test_that("varying formats for recipient lists work as expected", {
 #   Filenames with angle brackets < >
 #   With various extensions
 
+  # TODO: A test email with text lines > 80 characters, and some small binary
+  # attachment (image is fine). After calling generate_rfc2822 on it, ensure
+  # that grepl("(?<!\\r)\n", str, perl = TRUE) is FALSE
+
 })

--- a/tests/testthat/test-mime.R
+++ b/tests/testthat/test-mime.R
@@ -152,7 +152,7 @@ test_that("varying formats for recipient lists work as expected", {
   blastula::prepare_test_message(
     incl_ggplot = FALSE, incl_image = FALSE
   ) %>%
-    add_attachment(file = "tests/testthat/rstudio_logo.png") %>%
+    add_attachment(file = file.path(path.package("blastula"), "tests/testthat/rstudio_logo.png")) %>%
     generate_rfc2822() %>%
     grepl("(?<!\\r)\n", ., perl = TRUE) %>%
     expect_false()


### PR DESCRIPTION
This was due to line endings being erroneously rewritten during the quoted-printable encoding phase

Fixes #150, #140, #93, #124

## Testing notes

Look at an email sent from Blastula, using Outlook on Windows.