### PR TITLE
Connect email width

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Language: en-US

--- a/R/blastula_email_format.R
+++ b/R/blastula_email_format.R
@@ -1,5 +1,7 @@
 #' The R Markdown `blastula_email` output format
 #'
+#' @param content_width The width of the rendered HTML content. By default, this
+#'   is set to `1000px`.
 #' @param toc If you would like an automatically-generated table of contents in
 #'   the output email, choose `TRUE`. By default, this is `FALSE` where no table
 #'   of contents will be generated.
@@ -41,7 +43,8 @@
 #' @param ... Specify other options in [rmarkdown::html_document()].
 #'
 #' @export
-blastula_email <- function(toc = FALSE,
+blastula_email <- function(content_width = "1000px",
+                           toc = FALSE,
                            toc_depth = 3,
                            toc_float = FALSE,
                            number_sections = FALSE,
@@ -70,6 +73,7 @@ blastula_email <- function(toc = FALSE,
       pandoc_args,
       "--variable=rsc-footer:1",
       # Note bash escaping is handled by R Markdown (via shQuote())
+      paste0("--variable=content-width:", content_width),
       paste0(
         "--variable=rsc-date-time:", add_readable_time(time = Sys.time())),
       paste0(

--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -84,38 +84,11 @@ border-color: #34495e !important;
 }
 </style>
 </head>
-<body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
-<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;">
-<tr>
-<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;"><br /></td>
-<td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 580px; padding: 10px; width: 580px;">
-<div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 580px; padding: 10px;">
-
-<!-- START CENTERED WHITE CONTAINER -->
-<span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;"></span>
-<table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 3px;">
-
-<!-- START MAIN CONTENT AREA -->
-<tr>
-<td class="wrapper" style="font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 20px;">
-<table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
-<tr>
-<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
-<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">$body$</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-
-<!-- END MAIN CONTENT AREA -->
-</table>
+<body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 20px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+<div class="content" style="box-sizing: border-box; padding: 10px; width: $content-width$; max-width: 100%; margin: 0 auto; background-color: white;">$body$</div>
 
 <!-- START FOOTER -->
-<div class="footer" style="clear: both; Margin-top: 10px; text-align: left; width: 100%;">
-<table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
-<tr>
-<td class="content-block powered-by" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; color: #999999; text-align: left;">
+<div class="footer" style="width: $content-width$; max-width: 100%; margin: 10px auto; font-size: 12px; color: #999999;">
 $for(include-after)$
 $include-after$
 $endfor$
@@ -130,17 +103,7 @@ Latest Version: <a href="$rsc-report-url$">$rsc-report-url$</a></p>
 
 <p>If HTML documents are attached, they may not render correctly when viewed in some email clients. For a better experience, download HTML documents to disk before opening in a web browser.</p>
 $endif$
-</td>
-</tr>
-</table>
 </div>
 <!-- END FOOTER -->
-
-<!-- END CENTERED WHITE CONTAINER -->
-</div>
-</td>
-<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;"><br /></td>
-</tr>
-</table>
 </body>
 </html>

--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -1,94 +1,69 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta name="viewport" content="width=device-width">
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="utf-8"> <!-- utf-8 works for most cases -->
+<meta name="viewport" content="width=device-width"> <!-- Forcing initial-scale shouldn't be necessary -->
+<meta http-equiv="X-UA-Compatible" content="IE=edge"> <!-- Use the latest (edge) version of IE rendering engine -->
+<meta name="x-apple-disable-message-reformatting">  <!-- Disable auto-scale in iOS 10 Mail entirely -->
+<meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no"> <!-- Tell iOS not to automatically link certain text strings. -->
+<meta name="color-scheme" content="light">
+<meta name="supported-color-schemes" content="light">
+<!-- What it does: Makes background images in 72ppi Outlook render at correct size. -->
+<!--[if gte mso 9]>
+<xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+<![endif]-->
+<title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
 <style>
-@media only screen and (max-width: 620px) {
-table[class=body] h1 {
-font-size: 28px !important;
-margin-bottom: 10px !important;
+body {
+font-family: Helvetica, sans-serif;
+font-size: 14px;
 }
-table[class=body] p,
-table[class=body] ul,
-table[class=body] ol,
-table[class=body] td,
-table[class=body] span,
-table[class=body] a {
-font-size: 16px !important;
+.content {
+background-color: white;
 }
-table[class=body] .wrapper,
-table[class=body] .article {
-padding: 10px !important;
+.content .message-block {
+margin-bottom: 24px;
 }
-table[class=body] .content {
-padding: 0 !important;
+.header .message-block, .footer message-block {
+margin-bottom: 12px;
 }
-table[class=body] .container {
-padding: 0 !important;
-width: 100% !important;
-}
-table[class=body] .main {
-border-left-width: 0 !important;
-border-radius: 0 !important;
-border-right-width: 0 !important;
-}
-table[class=body] .btn table {
-width: 100% !important;
-}
-table[class=body] .btn a {
-width: 100% !important;
-}
-table[class=body] .img-responsive {
-height: auto !important;
-max-width: 100% !important;
-width: auto !important;
-}
-}
-
-/* -------------------------------------
-PRESERVE THESE STYLES IN THE HEAD
-------------------------------------- */
-@media all {
-
 img {
-max-width: 100% !important;
+max-width: 100%;
 }
-
-.ExternalClass {
+@media only screen and (max-width: 767px) {
+.container {
 width: 100%;
 }
-.ExternalClass,
-.ExternalClass p,
-.ExternalClass span,
-.ExternalClass font,
-.ExternalClass td,
-.ExternalClass div {
-line-height: 100%;
+.articles {
+display: block;
 }
-.apple-link a {
-color: inherit !important;
-font-family: inherit !important;
-font-size: inherit !important;
-font-weight: inherit !important;
-line-height: inherit !important;
-text-decoration: none !important;
-}
-.btn-primary table td:hover {
-background-color: #34495e !important;
-}
-.btn-primary a:hover {
-background-color: #34495e !important;
-border-color: #34495e !important;
+.article {
+display: block;
+width: 100%;
+margin-bottom: 24px;
 }
 }
 </style>
 </head>
-<body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 20px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
-<div class="content" style="box-sizing: border-box; padding: 10px; width: $content-width$; max-width: 100%; margin: 0 auto; background-color: white;">$body$</div>
-
-<!-- START FOOTER -->
-<div class="footer" style="width: $content-width$; max-width: 100%; margin: 10px auto; font-size: 12px; color: #999999;">
+<body style="background-color:#f6f6f6;font-family:Helvetica, sans-serif;color:#222;margin:0;padding:0;">
+<table width="85%" align="center" class="container" style="max-width: $content-width$;">
+<tr>
+<td style="padding:24px;">
+<div class="header" style="font-family:Helvetica, sans-serif;color:#999999;font-size:12px;font-weight:normal;margin:0 0 24px 0;text-align:center;">
+$for(include-before)$
+$include-before$
+$endfor$
+</div>
+<table width="100%" class="content" style="background-color:white;">
+<tr>
+<td style="padding:12px;">$body$</td>
+</tr>
+</table>
+<div class="footer" style="font-family:Helvetica, sans-serif;color:#999999;font-size:12px;font-weight:normal;margin:24px 0 0 0;">
 $for(include-after)$
 $include-after$
 $endfor$
@@ -104,6 +79,8 @@ Latest Version: <a href="$rsc-report-url$">$rsc-report-url$</a></p>
 <p>If HTML documents are attached, they may not render correctly when viewed in some email clients. For a better experience, download HTML documents to disk before opening in a web browser.</p>
 $endif$
 </div>
-<!-- END FOOTER -->
+</td>
+</tr>
+</table>
 </body>
 </html>

--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -38,12 +38,11 @@ max-width: 100%;
 .container {
 width: 100%;
 }
-.articles {
-display: block;
-}
-.article {
+.articles, .articles tr, .articles td {
 display: block;
 width: 100%;
+}
+.article {
 margin-bottom: 24px;
 }
 }

--- a/man/blastula_email.Rd
+++ b/man/blastula_email.Rd
@@ -5,6 +5,7 @@
 \title{The R Markdown \code{blastula_email} output format}
 \usage{
 blastula_email(
+  content_width = "1000px",
   toc = FALSE,
   toc_depth = 3,
   toc_float = FALSE,
@@ -26,6 +27,9 @@ blastula_email(
 )
 }
 \arguments{
+\item{content_width}{The width of the rendered HTML content. By default, this
+is set to \verb{1000px}.}
+
 \item{toc}{If you would like an automatically-generated table of contents in
 the output email, choose \code{TRUE}. By default, this is \code{FALSE} where no table
 of contents will be generated.}


### PR DESCRIPTION
This PR adds the `content_width` argument to `blastula_email()`, allowing for a custom content width for rendered .Rmd in Connect emails. The Connect Pandoc HTML template is also greatly simplified.