### PR TITLE
Improve grammar in Connect email footer message text

### DIFF
--- a/inst/rmd/template.html
+++ b/inst/rmd/template.html
@@ -121,7 +121,7 @@ $include-after$
 $endfor$
 $if(rsc-footer)$
 $if(include-after)$<hr/>$endif$
-<p>This message was generated at $rsc-date-time$.</p>
+<p>This message was generated on $rsc-date-time$.</p>
 
 <p>This Version: <a href="$rsc-report-rendering-url$">$rsc-report-rendering-url$</a><br/>
 Latest Version: <a href="$rsc-report-url$">$rsc-report-url$</a></p>


### PR DESCRIPTION
This simply replaces a single preposition in template text.

 `This message was generated at $rsc-date-time$.` ->  `This message was generated on $rsc-date-time$.`

Fixes: #123 