### PR TITLE
Allowed the user to control the width of an image in add_image

### DIFF
--- a/R/add_image.R
+++ b/R/add_image.R
@@ -2,7 +2,8 @@
 #'
 #' Add a local image inside the body of the email with this helper function.
 #'
-#' @param file A path to an image file.
+#' @param file A path to an image file.ld like your image to be.
+#' @param img_width The width in pixels you would like the image to be.
 #' @param alt Text description of image passed to the `alt` attribute inside of
 #'   the image (`<img>`) tag for use when image loading is disabled and on
 #'   screen readers. `NULL` default produces blank (`""`) alt text.
@@ -41,7 +42,7 @@
 #' if (interactive()) email
 #'
 #' @export
-add_image <- function(file, alt = NULL) {
+add_image <- function(file, img_width = "520",alt = NULL) {
 
   # Construct a CID based on the filename
   # with a random string prepended to it
@@ -68,7 +69,7 @@ add_image <- function(file, alt = NULL) {
   paste0(
     "<img cid=\"", cid,
     "\" src=\"", uri,
-    "\" width=\"520\" alt=\"", alt_text %>% htmltools::htmlEscape(attribute = TRUE), "\"/>\n"
+    "\" width=\"",img_width,"\" alt=\"", alt_text %>% htmltools::htmlEscape(attribute = TRUE), "\"/>\n"
   )
 }
 

--- a/man/add_image.Rd
+++ b/man/add_image.Rd
@@ -4,10 +4,12 @@
 \alias{add_image}
 \title{Create an HTML fragment for an embedded image}
 \usage{
-add_image(file, alt = NULL)
+add_image(file, img_width = "520", alt = NULL)
 }
 \arguments{
-\item{file}{A path to an image file.}
+\item{file}{A path to an image file.ld like your image to be.}
+
+\item{img_width}{The width in pixels you would like the image to be.}
 
 \item{alt}{Text description of image passed to the \code{alt} attribute inside of
 the image (\verb{<img>}) tag for use when image loading is disabled and on


### PR DESCRIPTION
I had some trouble today when adding a static image in my email. I thought this might be a small fix that could allow the user to change that. I originally used gsub to replace the 520 and thought to myself this might be useful. 

Thank you for making this package. I hope this edit might help.