### PR TITLE
Doc completion for `delete_credential_key()`

### DIFF
--- a/R/retrieve_credentials.R
+++ b/R/retrieve_credentials.R
@@ -45,9 +45,13 @@ view_credential_keys <- function() {
 #' function cannot be used without that package being available on the system.
 #' We can use `install.packages("keyring")` to install **keyring**.
 #'
+#' @param id The identifying label for the credential key. Use the same `id`
+#'   that was used to create the key with the [create_smtp_creds_key()]
+#'   function.
+#'
 #' @examples
 #' # Delete the credential key with
-#' # the `id` value of `outlook`
+#' # the `id` value of "outlook"
 #'
 #' # delete_credential_key("outlook")
 #'

--- a/man/delete_credential_key.Rd
+++ b/man/delete_credential_key.Rd
@@ -6,6 +6,11 @@
 \usage{
 delete_credential_key(id)
 }
+\arguments{
+\item{id}{The identifying label for the credential key. Use the same \code{id}
+that was used to create the key with the \code{\link[=create_smtp_creds_key]{create_smtp_creds_key()}}
+function.}
+}
 \description{
 It may be important to delete a credential key and the
 \code{delete_credential_key()} function makes this possible. To understand which
@@ -20,7 +25,7 @@ We can use \code{install.packages("keyring")} to install \strong{keyring}.
 }
 \examples{
 # Delete the credential key with
-# the `id` value of `outlook`
+# the `id` value of "outlook"
 
 # delete_credential_key("outlook")
 


### PR DESCRIPTION
I was missing the param value for the `id` argument in the new `delete_credential_key()` function. This PR adds that and updates the associated .Rd file.