### PR TITLE
Update email examples

### DIFF
--- a/tests/manual_tests/internal_message_email.R
+++ b/tests/manual_tests/internal_message_email.R
@@ -1,17 +1,19 @@
 library(blastula)
 library(glue)
 
-# Attribution Information
-#
-# Text and images taken entirely from this public page:
-# https://www.manulife.com/en/about/sustainability/ceo-letter.html
+# Attribution Information available in `README-attribution.txt`
 
-rg_sig <- add_image("tests/manual_tests/rg_sig.jpg") %>%
-  gsub("width=\"520\"", "width=\"10%\"", .)
+rg_sig <-
+  add_image(
+    "tests/manual_tests/rg_sig.jpg",
+    align = "left",
+    width = "10%"
+  )
 
 email <-
   compose_email(
-    body = md(glue::glue("
+    body = md(glue(
+"
 ## A *message* from our President and CEO
 
 In my discussions with employees, one thing I see consistently demonstrated \\

--- a/tests/manual_tests/new_releases_email.R
+++ b/tests/manual_tests/new_releases_email.R
@@ -1,11 +1,21 @@
 library(blastula)
 library(glue)
 
-title_banner <- add_image("tests/manual_tests/new_r_package_releases.png") %>%
-  gsub("width=\"520\"", "width=\"100%\"", .)
+# Attribution Information available in `README-attribution.txt`
 
-r_packages_gif <- add_image("tests/manual_tests/r_package_updates.gif") %>%
-  gsub("width=\"520\"", "width=\"100%\"", .)
+title_banner <-
+  add_image(
+    "tests/manual_tests/new_r_package_releases.png",
+    alt = "New Releases",
+    width = "100%"
+  )
+
+r_packages_gif <-
+  add_image(
+    "tests/manual_tests/r_package_updates.gif",
+    alt = "R Package Updates for stationaRy, pointblank, DiagrammeR, and blastula",
+    width = "100%"
+  )
 
 cta_github <-
   add_cta_button(
@@ -16,7 +26,7 @@ cta_github <-
 
 email <-
   compose_email(
-    body = blastula::md(glue::glue("
+    body = md(glue("
 
 {title_banner}
 
@@ -34,12 +44,12 @@ measurements, hundreds of met fields. The update makes it easier than ever \\
 to get this data in the form you need. \u2600 \u2601
 
 You got data? Of course you do. Ever check the quality of it? You really \\
-oughta. The **pointblank** package makes that whole process much easier. \\
-It's like **testthat**, but, for data. Plus there are fancier reports \\
+oughta. The **pointblank** package makes that whole process so much easier. \\
+It's like **testthat**, but, for data. Plus, there are fancier reports \\
 in this update! \u2714 \u2714 \u2714
 
 Data is sometimes *graph-y* and **DiagrammeR** can help you work with \\
-this type of data. This update stamps out a few nasty bugs adds a few new \\
+this type of data. This update stamps out a few nasty bugs and adds a few new \\
 functions for visualizing graphs. Check it out if you have a graph \\
 problem. &xcirc;&#9476;&xcirc;
 

--- a/tests/manual_tests/newsletter_email.R
+++ b/tests/manual_tests/newsletter_email.R
@@ -1,9 +1,8 @@
 library(blastula)
 
-# Attribution Information
-#
-# Uses 'free-to-use' photos from https://photos.icons8.com (conditional on linking back);
-# more information here: https://icons8.com/license
+# Attribution Information available in `README-attribution.txt`
+
+# Note: images were previously deployed to Imgur using the following calls:
 
 # https://i.imgur.com/gpVMFcW.jpg
 # add_imgur_image(
@@ -36,9 +35,10 @@ email <-
         block_spacer(),
         block_title("Exciting New VR Innovations"),
         block_spacer(),
-        block_text(paste0(
-          "VR is here to stay! New hardware offerings by major VR players are heating up ",
-          "the shelves and, later, getting people moving in their living rooms!")),
+        block_text(
+"VR is here to stay! New hardware offerings by major VR players are heating up
+the shelves and, later, getting people moving in their living rooms!"
+        ),
         block_articles(
           article(
             image = "https://i.imgur.com/18fcpkZ.jpg",
@@ -52,8 +52,8 @@ email <-
             image = "https://i.imgur.com/5aJawp2.jpg",
             title = "Hyperreal",
             content =
-              "By utilizing a combination of the Hyperreal headset (and
-               additional measures), one can have the sensation of being
+              "By utilizing a combination of the Hyperreal headset and
+               additional measures, one can have the sensation of being
                truly immersed in the VR world."
           ),
           article(
@@ -65,6 +65,7 @@ email <-
                ounces, using a waveguide display and foveated rendering."
           )
         ),
+        block_spacer(),
         block_articles(
           article(
             image = "https://i.imgur.com/8sH6Ggt.jpg",
@@ -73,15 +74,19 @@ email <-
               "Soon, we expect VR to be fashionable! Just take a look at
                this image for a glimpse of haute couture: VR Style."
           )),
-        block_text(
-          "This wraps up the May 2020 Edition of our monthly newsletter that
-           showcases the latest in VR technologies. Next month, we'll provide
-           info on can't miss VR and AR events in 2020."
-        )
+        block_text(md(
+"### See you next Month!
+ This wraps up the May 2020 Edition of our monthly newsletter that
+ showcases the latest in VR technologies. Next month, we'll provide
+ info on can't miss VR and AR events in 2020."
+        ))
       ),
     footer =
       blocks(
-        block_text("Thanks for reading our newsletter. You can also find us here:"),
+        block_text(
+          md("Thanks for reading our newsletter. You can also find us here:<br>"),
+          align = "center"
+        ),
         block_social_links(
           social_link(
             service = "twitter",
@@ -104,7 +109,10 @@ email <-
             variant = "color"
           )
         ),
-        block_text("All photos obtained from https://photos.icons8.com")
+        block_text(
+          md("All photos obtained from https://photos.icons8.com<br>"),
+          align = "center"
+        )
       )
   )
 

--- a/tests/manual_tests/pizzaplace_email.R
+++ b/tests/manual_tests/pizzaplace_email.R
@@ -5,13 +5,15 @@ library(scales)
 library(emo)
 library(glue)
 
+# Attribution Information available in `README-attribution.txt`
+
 # Create short labels for months (displays
 # better for small plots in email messages)
 initial_months <-
   c("D",
     "J", "F", "M", "A", "M", "J",
     "J", "A", "S", "O", "N", "D",
-    " ")
+    "J")
 
 # Create a plot using the `pizzaplace` dataset
 pizza_plot <-
@@ -45,23 +47,24 @@ pizza_plot <-
     plot.caption = element_text(color = "grey25"),
     plot.subtitle = element_text(color = "grey25"),
     plot.margin = unit(c(20, 20, 20, 20), "points"),
+    plot.title.position = "plot",
     legend.box.spacing = unit(2, "points"),
-    legend.position = "bottom")
+    legend.position = "bottom"
+  )
 
 # Make the plot suitable for mailing by
 # converting it to an HTML fragment
 pizza_plot_email <-
   pizza_plot %>%
-  add_ggplot()
+  add_ggplot(alt = "Pizza Sales Plots by type of pizza (in 2015)")
 
 # Create `sizes_order` and `types_order` to
 # support the ordering of pizza sizes and types
 sizes_order <- c("S", "M", "L", "XL", "XXL")
 types_order <- c("Classic", "Chicken", "Supreme", "Veggie")
 
-# Create a gt table that uses the `pizzaplace`
-# dataset; ensure that `as_raw_html()` is used
-# (that gets us an HTML fragement with inlined
+# Create a gt table that uses the `pizzaplace` dataset; ensure that
+# `as_raw_html()` is used (that gets us an HTML fragment with inlined
 # CSS styles)
 pizza_tab_email <-
   pizzaplace %>%
@@ -102,8 +105,6 @@ pizza_tab_email <-
     summary_row.background.color = "#FFFAAA",
     row_group.background.color = "#E6EFFC",
     table.font.size = "small",
-    heading.title.font.size = "small",
-    heading.subtitle.font.size = "x-small",
     row_group.font.size = "small",
     column_labels.font.size = "small",
     data_row.padding = "5px"
@@ -116,14 +117,11 @@ pizza_tab_email <-
     title = paste0("My ", emo::ji("pizza"), " sales in 2015"),
     subtitle = "Split by the type of pizza and the size"
   ) %>%
+  tab_options(table.width = pct(40)) %>%
   as_raw_html()
 
-
-# Create an email message using the
-# `compose_email()` function from the
-# blastula package
 email <-
-  blastula::compose_email(body = blastula::md(glue::glue("
+  compose_email(body = md(glue("
   Hello,
 
   Just wanted to let you know that pizza \\

--- a/tests/manual_tests/service_changes_email.R
+++ b/tests/manual_tests/service_changes_email.R
@@ -1,19 +1,19 @@
 library(blastula)
 library(glue)
 
+# Attribution Information available in `README-attribution.txt`
+
 gt_logo_image <-
-  add_image("tests/manual_tests/gt_logo.png") %>%
-  gsub("width=\"520\"", "width=\"100%\"", .)
+  add_image("tests/manual_tests/gt_logo.png", width = "100%")
 
 gt_logo_image_small <-
-  add_image("tests/manual_tests/gt_logo.png") %>%
-  gsub("width=\"520\"", "width=\"150\"", .)
+  add_image("tests/manual_tests/gt_logo.png", width = 150)
 
 order_number <- "0232358329"
 
 email <-
   compose_email(
-    body = md(glue::glue(
+    body = md(glue(
 "
 {gt_logo_image}
 
@@ -56,7 +56,7 @@ Mit freundlichen Grüßen <br>
 Ihr Glänzend Telekom Team
 
 ")),
-    footer = md(glue::glue(
+    footer = md(glue(
 "
 {gt_logo_image_small}
 

--- a/tests/manual_tests/validation_report_email.R
+++ b/tests/manual_tests/validation_report_email.R
@@ -3,6 +3,8 @@ library(tidyverse)
 library(pointblank)
 library(RSQLite)
 
+# Attribution Information available in `README-attribution.txt`
+
 # Create an in-memory SQLite database and connection
 con <- DBI::dbConnect(RSQLite::SQLite(), dbname = ":memory:")
 
@@ -17,8 +19,13 @@ dplyr::copy_to(
 
 tbl_sqlite <- dplyr::tbl(con, "small_table")
 
+# Perform a pointblank validation with an agent
 agent <-
-  create_agent(tbl = tbl_sqlite) %>%
+  create_agent(
+    tbl = tbl_sqlite,
+    name = "sqlite: small_table",
+    actions = action_levels(warn_at = 0.2, stop_at = 0.45),
+  ) %>%
   col_vals_gt(vars(d), 100) %>%
   col_vals_gte(vars(c), 2, na_pass = TRUE) %>%
   col_vals_equal(vars(e), 1, preconditions = ~tbl %>% dplyr::filter(e == 1)) %>%
@@ -53,10 +60,6 @@ agent <-
   ) %>%
   interrogate()
 
-email <-
-  agent %>%
-  email_preview(
-    msg_body = stock_msg_body()
-  )
+email <- email_preview(agent)
 
 email

--- a/tests/manual_tests/validation_report_email.R
+++ b/tests/manual_tests/validation_report_email.R
@@ -24,7 +24,7 @@ agent <-
   create_agent(
     tbl = tbl_sqlite,
     name = "sqlite: small_table",
-    actions = action_levels(warn_at = 0.2, stop_at = 0.45),
+    actions = action_levels(warn_at = 0.2, stop_at = 0.35, notify_at = 0.45),
   ) %>%
   col_vals_gt(vars(d), 100) %>%
   col_vals_gte(vars(c), 2, na_pass = TRUE) %>%

--- a/tests/manual_tests/welcome_email.R
+++ b/tests/manual_tests/welcome_email.R
@@ -1,21 +1,26 @@
 library(blastula)
 library(glue)
 
-# Attribution Information
-#
-# `young_adult_male.jpg` is a generated photo obtained from https://generated.photos/
-#
-# `msms_logo.png` was generated using the logo generation tools at https://looka.com/
+# Attribution Information available in `README-attribution.txt`
 
-seb_image <- add_image("tests/manual_tests/young_adult_male.jpg", align = "center")
+seb_image <-
+  add_image(
+    "tests/manual_tests/young_adult_male.jpg",
+    alt = "Seb himself",
+    align = "center"
+  )
 
 company_logo <-
-  add_image("tests/manual_tests/msms_logo.png", alt = "msms logo") %>%
-  gsub("width=\"520\"", "width=\"100%\"", .)
+  add_image(
+    "tests/manual_tests/msms_logo.png",
+    alt = "msms logo",
+    width = "50%",
+    align = "center"
+  )
 
 email <-
   compose_email(
-    body = md(glue::glue("
+    body = md(glue("
 
   ### Welcome Sebastian (Seb) Génin to Our Team! &#x263A; &#x263A; &#x263A;
 
@@ -34,7 +39,7 @@ email <-
 
   &nbsp;&nbsp;&nbsp;&mdash;R.M.D. \\
 ")),
-    footer = blastula::md(glue::glue("
+    footer = md(glue("
 
   {company_logo}
 


### PR DESCRIPTION
This will restore the appearance of the examples to the layouts that had before the large-scale changes.

Fixes: #185 