### PR TITLE
content_width was not being respected for all uses of blastula_email

### DIFF
--- a/R/blastula_email_format.R
+++ b/R/blastula_email_format.R
@@ -63,12 +63,7 @@ blastula_email <- function(content_width = "1000px",
                            connect_footer = FALSE,
                            ...) {
 
-  if (!grepl("^[0-9.]*?(|px|%)$", content_width)) {
-    stop("The value for `content_width` is incorrectly formatted:\n",
-         "* Use either as a px value (e.g., \"800px\"), a percent value (e.g., \"80%\"), ",
-         "or a standalone numeric value for px (e.g., 800 -> \"800px\")",
-         call. = FALSE)
-  }
+  content_width <- htmltools::validateCssUnit(content_width)
   
   if (template == "blastula") {
     template <- system.file("rmd", "template.html", package = "blastula")

--- a/R/blastula_email_format.R
+++ b/R/blastula_email_format.R
@@ -67,13 +67,12 @@ blastula_email <- function(content_width = "1000px",
     template <- system.file("rmd", "template.html", package = "blastula")
   }
 
-  pandoc_args <- NULL
+  # Note bash escaping is handled by R Markdown (via shQuote())
+  pandoc_args <- paste0("--variable=content-width:", content_width)
   if (isTRUE(connect_footer)) {
     pandoc_args <- c(
       pandoc_args,
       "--variable=rsc-footer:1",
-      # Note bash escaping is handled by R Markdown (via shQuote())
-      paste0("--variable=content-width:", content_width),
       paste0(
         "--variable=rsc-date-time:", add_readable_time(time = Sys.time())),
       paste0(

--- a/R/blastula_email_format.R
+++ b/R/blastula_email_format.R
@@ -63,6 +63,13 @@ blastula_email <- function(content_width = "1000px",
                            connect_footer = FALSE,
                            ...) {
 
+  if (!grepl("^[0-9.]*?(|px|%)$", content_width)) {
+    stop("The value for `content_width` is incorrectly formatted:\n",
+         "* Use either as a px value (e.g., \"800px\"), a percent value (e.g., \"80%\"), ",
+         "or a standalone numeric value for px (e.g., 800 -> \"800px\")",
+         call. = FALSE)
+  }
+  
   if (template == "blastula") {
     template <- system.file("rmd", "template.html", package = "blastula")
   }


### PR DESCRIPTION
This is because the code for passing content_width to the template was
in a conditional that checked for the connect footer.

## Testing notes

Create an Rmd that includes this yaml:

```
output:
  blastula::blastula_email:
    content_width: 600px
```

The `content_width` was previously being dropped UNLESS rendered using `render_connect_email`, i.e. simply knitting this template wouldn't include the content_width.
