### PR TITLE
Documentation fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,7 +50,7 @@ There are new functions for integrating **blastula** with R Markdown publishing 
 
 * Functions from the `getPass` package are used internally to ask for a password whenever necessary during an interactive session
 
-* Functions from the `keyring` package are used internally to aid in the storage and retrieval of STMP config/credentials information in the system-wide key-value store (which is cross platform)
+* Functions from the `keyring` package are used internally to aid in the storage and retrieval of SMTP config/credentials information in the system-wide key-value store (which is cross platform)
 
 # blastula 0.2.1
 

--- a/R/blastula_email_format.R
+++ b/R/blastula_email_format.R
@@ -1,7 +1,9 @@
 #' The R Markdown `blastula_email` output format
 #'
 #' @param content_width The width of the rendered HTML content. By default, this
-#'   is set to `1000px`.
+#'   is set to `1000px`. Using widths less than `600px` is generally not advised
+#'   but, if necessary, be sure to test such HTML emails with a wide range of
+#'   email clients before sending to the intended recipients.
 #' @param toc If you would like an automatically-generated table of contents in
 #'   the output email, choose `TRUE`. By default, this is `FALSE` where no table
 #'   of contents will be generated.
@@ -64,7 +66,7 @@ blastula_email <- function(content_width = "1000px",
                            ...) {
 
   content_width <- htmltools::validateCssUnit(content_width)
-  
+
   if (template == "blastula") {
     template <- system.file("rmd", "template.html", package = "blastula")
   }

--- a/R/bls_template.R
+++ b/R/bls_template.R
@@ -1,4 +1,4 @@
-#' Default template for `compose_email`
+#' Default template for `compose_email()`
 #'
 #' A template function that is suitable for using as the `template` argument of
 #' [compose_email()]. Template functions should generally not be called
@@ -11,16 +11,22 @@
 #'   [htmltools::tags()] or [htmltools::HTML()]), or `NULL` to omit.
 #' @param title Plain text title to be used for the `<title>` element; may be
 #'   displayed in mobile phone notifications.
-#' @param content_width The width that should be used for the content area. This
-#'   should NOT be specified CSS units like `"600px"`, but as either an integer
-#'   (for pixels, e.g. `600`) or a percent string like `"85%"`.
+#' @param content_width The width that should be used for the content area. By
+#'   default, this is set to `1000px`. Using widths less than `600px` is
+#'   generally not advised but, if necessary, be sure to test such HTML emails
+#'   with a wide range of email clients before sending to the intended
+#'   recipients.
 #' @param font_family The CSS value to use for `font-family`.
 #'
 #' @return A string containing a complete HTML document.
 #'
 #' @export
-blastula_template <- function(html_body, html_header, html_footer, title,
-  content_width = "1000px", font_family = "Helvetica, sans-serif") {
+blastula_template <- function(html_body,
+                              html_header,
+                              html_footer,
+                              title,
+                              content_width = "1000px",
+                              font_family = "Helvetica, sans-serif") {
 
   result <- htmltools::renderTags(
     tagList(

--- a/R/compose_email.R
+++ b/R/compose_email.R
@@ -66,10 +66,13 @@ compose_email <- function(body = NULL,
 
   # Generate the email message body
   body <-
-    template(title = title,
+    template(
+      title = title,
       html_header = header,
       html_body = body,
-      html_footer = footer, ...) %>%
+      html_footer = footer,
+      ...
+    ) %>%
     # In case the template used md() internally
     process_markdown() %>%
     as.character()

--- a/R/create_credentials.R
+++ b/R/create_credentials.R
@@ -8,7 +8,7 @@
 #' @param file The output filename for the credentials file.
 #' @param user The username for the email account. Typically, this is the email
 #'   address associated with the account.
-#' @param provider An optional email provider shortname for autocompleting STMP
+#' @param provider An optional email provider shortname for autocompleting SMTP
 #'   configuration details (the `host`, `port`, `use_ssl` options). Options
 #'   currently include `gmail`, `outlook`, and `office365`. If nothing is
 #'   provided then values for `host`, `port`, and `use_ssl` are expected.

--- a/R/creds_helpers.R
+++ b/R/creds_helpers.R
@@ -28,7 +28,7 @@
 #'
 #' @param user The username for the email account. Typically, this is the email
 #'   address associated with the account.
-#' @param provider An optional email provider shortname for autocompleting STMP
+#' @param provider An optional email provider shortname for autocompleting SMTP
 #'   configuration details (the `host`, `port`, `use_ssl` options). Options
 #'   currently include `gmail`, `outlook`, and `office365`. If nothing is
 #'   provided then values for `host`, `port`, and `use_ssl` are expected.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -14,6 +14,7 @@ reference:
     - compose_email
     - add_attachment
     - prepare_test_message
+    - blastula_template
 
   - title: Add Inline Components
     desc: >

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -58,6 +58,8 @@ reference:
     - create_smtp_creds_key
     - credential_helpers
     - view_credential_keys
+    - delete_credential_key
+    - delete_all_credential_keys
 
   - title: Email Sending through RStudio Connect
     desc: >

--- a/man/blastula_email.Rd
+++ b/man/blastula_email.Rd
@@ -28,7 +28,9 @@ blastula_email(
 }
 \arguments{
 \item{content_width}{The width of the rendered HTML content. By default, this
-is set to \verb{1000px}.}
+is set to \verb{1000px}. Using widths less than \verb{600px} is generally not advised
+but, if necessary, be sure to test such HTML emails with a wide range of
+email clients before sending to the intended recipients.}
 
 \item{toc}{If you would like an automatically-generated table of contents in
 the output email, choose \code{TRUE}. By default, this is \code{FALSE} where no table

--- a/man/blastula_template.Rd
+++ b/man/blastula_template.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/bls_template.R
 \name{blastula_template}
 \alias{blastula_template}
-\title{Default template for \code{compose_email}}
+\title{Default template for \code{compose_email()}}
 \usage{
 blastula_template(
   html_body,
@@ -20,9 +20,11 @@ blastula_template(
 \item{title}{Plain text title to be used for the \verb{<title>} element; may be
 displayed in mobile phone notifications.}
 
-\item{content_width}{The width that should be used for the content area. This
-should NOT be specified CSS units like \code{"600px"}, but as either an integer
-(for pixels, e.g. \code{600}) or a percent string like \code{"85\%"}.}
+\item{content_width}{The width that should be used for the content area. By
+default, this is set to \verb{1000px}. Using widths less than \verb{600px} is
+generally not advised but, if necessary, be sure to test such HTML emails
+with a wide range of email clients before sending to the intended
+recipients.}
 
 \item{font_family}{The CSS value to use for \code{font-family}.}
 }

--- a/man/create_smtp_creds_file.Rd
+++ b/man/create_smtp_creds_file.Rd
@@ -19,7 +19,7 @@ create_smtp_creds_file(
 \item{user}{The username for the email account. Typically, this is the email
 address associated with the account.}
 
-\item{provider}{An optional email provider shortname for autocompleting STMP
+\item{provider}{An optional email provider shortname for autocompleting SMTP
 configuration details (the \code{host}, \code{port}, \code{use_ssl} options). Options
 currently include \code{gmail}, \code{outlook}, and \code{office365}. If nothing is
 provided then values for \code{host}, \code{port}, and \code{use_ssl} are expected.}

--- a/man/create_smtp_creds_key.Rd
+++ b/man/create_smtp_creds_key.Rd
@@ -26,7 +26,7 @@ cannot be an empty string and it cannot include hyphen characters.}
 \item{user}{The username for the email account. Typically, this is the email
 address associated with the account.}
 
-\item{provider}{An optional email provider shortname for autocompleting STMP
+\item{provider}{An optional email provider shortname for autocompleting SMTP
 configuration details (the \code{host}, \code{port}, \code{use_ssl} options). Options
 currently include \code{gmail}, \code{outlook}, and \code{office365}. If nothing is
 provided then values for \code{host}, \code{port}, and \code{use_ssl} are expected.}

--- a/man/credential_helpers.Rd
+++ b/man/credential_helpers.Rd
@@ -30,7 +30,7 @@ creds_file(file)
 \item{user}{The username for the email account. Typically, this is the email
 address associated with the account.}
 
-\item{provider}{An optional email provider shortname for autocompleting STMP
+\item{provider}{An optional email provider shortname for autocompleting SMTP
 configuration details (the \code{host}, \code{port}, \code{use_ssl} options). Options
 currently include \code{gmail}, \code{outlook}, and \code{office365}. If nothing is
 provided then values for \code{host}, \code{port}, and \code{use_ssl} are expected.}


### PR DESCRIPTION
The new `delete_credential_key()` and `delete_all_credential_keys()` functions need to appear in the pkgdown site. To fix this, the `_pkgdown.yml` file is now modified to include those entries. There are several typo fixes, correcting `STMP -> SMTP` in a few places.

Fixes: https://github.com/rich-iannone/blastula/issues/193