### PR TITLE
Specify width additionally in `style` attr for Apple Mail

### DIFF
--- a/R/add_image.R
+++ b/R/add_image.R
@@ -68,7 +68,7 @@ add_image <- function(file, alt = "", width = 520,
   uri <- get_image_uri(file = file)
 
   img <- tags$img(src = uri, alt = alt, width = width, align = float,
-    style = css(float = float))
+    style = css(float = float, width = htmltools::validateCssUnit(width)))
 
   if (!is.null(align)) {
     img <- panel(outer_align = align, inner_align = align,


### PR DESCRIPTION
This resolves an issue seen in Apple Mail clients where images are set to 100% width.

Fixes: #201 