### PR TITLE
Add additional documentation about `content_width`

### DIFF
--- a/R/compose_email.R
+++ b/R/compose_email.R
@@ -16,7 +16,10 @@
 #' @param ... Additional arguments to pass to the `template` function. If you're
 #'   using the default template, you can use `font_family` to control the base
 #'   font, and `content_width` to control the width of the main content; see
-#'   [blastula_template()].
+#'   [blastula_template()]. By default, the `content_width` is set to `1000px`.
+#'   Using widths less than `600px` is generally not advised but, if necessary,
+#'   be sure to test such HTML emails with a wide range of email clients before
+#'   sending to the intended recipients.
 #'
 #' @examples
 #' # Create a simple email message using

--- a/man/compose_email.Rd
+++ b/man/compose_email.Rd
@@ -26,7 +26,10 @@ HTML title text which may appear in limited circumstances.}
 \item{...}{Additional arguments to pass to the \code{template} function. If you're
 using the default template, you can use \code{font_family} to control the base
 font, and \code{content_width} to control the width of the main content; see
-\code{\link[=blastula_template]{blastula_template()}}.}
+\code{\link[=blastula_template]{blastula_template()}}. By default, the \code{content_width} is set to \verb{1000px}.
+Using widths less than \verb{600px} is generally not advised but, if necessary,
+be sure to test such HTML emails with a wide range of email clients before
+sending to the intended recipients.}
 
 \item{template}{An email template function to use. The default is
 \code{\link[=blastula_template]{blastula_template()}}.}


### PR DESCRIPTION
This adds some advice about `content_width` values to the `compose_email()` help article.